### PR TITLE
Handle TK_ALT events as AltPressed and AltReleased

### DIFF
--- a/src/terminal/input.rs
+++ b/src/terminal/input.rs
@@ -203,4 +203,8 @@ pub enum Event {
 	ControlPressed,
 	/// The Control key released.
 	ControlReleased,
+	/// The Alt key pressed (might repeat, if set in OS).
+	AltPressed,
+	/// The Alt key released.
+	AltReleased,
 }

--- a/src/terminal/mod.rs
+++ b/src/terminal/mod.rs
@@ -439,6 +439,7 @@ fn to_key_event(code: i32) -> Option<Event> {
 	match key {
 		ffi::TK_SHIFT   => Some(if released {Event::ShiftReleased}   else {Event::ShiftPressed}),
 		ffi::TK_CONTROL => Some(if released {Event::ControlReleased} else {Event::ControlPressed}),
+		ffi::TK_ALT     => Some(if released {Event::AltReleased}     else {Event::AltPressed}),
 		key             => {
 			let ctrl  = ffi::check(ffi::TK_CONTROL);
 			let shift = ffi::check(ffi::TK_SHIFT);


### PR DESCRIPTION
For #5, this exposes nabijaczleweli/BearLibTerminal.rs@a14f5ed997400b12131a5f99481a56cebe71b41a on the safe Rust side as `AltPressed` and `AltReleased`.