### PR TITLE
Fix in the `Bitmap` documentation

### DIFF
--- a/src/terminal/config/font.rs
+++ b/src/terminal/config/font.rs
@@ -116,7 +116,7 @@ pub enum Align {
 // }
 
 
-/// A bitmap font override segment repr, constructed with [`true_type()`](fn.true_type.html).
+/// A bitmap font override segment repr, constructed with [`bitmap()`](fn.bitmap.html).
 ///
 /// Refer to [the official documentation](http://foo.wyrd.name/en:bearlibterminal:reference:configuration#font_and_tileset_management).
 #[derive(Clone, Debug, Eq, PartialEq, Hash)]


### PR DESCRIPTION
Fixes a small error in the documentation (probably the result of a copy and paste): the documentation of `Bitmap` was the same as `TrueType`, while it should refer to the `bitmap` function instead of `true_type`.