### PR TITLE
Allow for named fonts

### DIFF
--- a/src/terminal/config/font.rs
+++ b/src/terminal/config/font.rs
@@ -69,6 +69,8 @@ pub fn true_type<T: AsRef<Path>>(origin: Origin, path: T, tile_size: Size) -> Tr
 pub enum Origin {
 	/// `font`
 	Root,
+	/// `named font`
+	Named(String),
 	/// `0xNNNN`
 	Offset(char),
 }
@@ -291,6 +293,7 @@ impl fmt::Display for Origin {
 	fn fmt(&self, formatter: &mut fmt::Formatter) -> fmt::Result {
 		match self {
 			&Origin::Root      => formatter.write_str("font"),
+			&Origin::Named(n)  => formatter.write_str("{} font", &n),
 			&Origin::Offset(o) => formatter.write_str(&*&format!("0x{:X}", o as i32)),
 		}
 	}

--- a/src/terminal/config/font.rs
+++ b/src/terminal/config/font.rs
@@ -27,6 +27,7 @@
 
 use std::fmt;
 use std::path::Path;
+use std::borrow::Cow;
 use geometry::Size;
 use terminal::config::{ConfigPart, escape_config_string};
 
@@ -70,7 +71,7 @@ pub enum Origin {
 	/// `font`
 	Root,
 	/// `named font`
-	Named(String),
+	Named(Cow<'static, str>),
 	/// `0xNNNN`
 	Offset(char),
 }

--- a/src/terminal/config/font.rs
+++ b/src/terminal/config/font.rs
@@ -292,9 +292,9 @@ impl ConfigPart for TrueType {
 impl fmt::Display for Origin {
 	fn fmt(&self, formatter: &mut fmt::Formatter) -> fmt::Result {
 		match self {
-			&Origin::Root      => formatter.write_str("font"),
-			&Origin::Named(n)  => formatter.write_str("{} font", &n),
-			&Origin::Offset(o) => formatter.write_str(&*&format!("0x{:X}", o as i32)),
+			&Origin::Root          => formatter.write_str("font"),
+			&Origin::Named(ref n)  => formatter.write_str(&*&format!("{} font", &n)),
+			&Origin::Offset(o)     => formatter.write_str(&*&format!("0x{:X}", o as i32)),
 		}
 	}
 }


### PR DESCRIPTION
Allow naming of fonts, as in the `runic` example in the [bear_lib_terminal doc](http://foo.wyrd.name/en:bearlibterminal:reference:configuration#font_and_tileset_management).